### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,32 @@
 # Luma | Framework Component Changelog
 
+## [1.3.0] - 2024-05-06
+### Added
+- Added `copyEnv` step to `Installer` - copies `config/.env.example` to `config/.env`.
+- Added `CacheClearCommand` to work alongside planned `bin/luma` file.
+- Now caching config parameters.
+- Added `symfony/command`
+
+### Changed
+- N/A
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- Updated the view cache directory to `cache/views`.
+
+### Security
+- N/A
+
+---
+
 ## [1.2.0] - 2024-05-05
 ### Added
-- Added `config.yaml` and `Luma::getConfigParam`
+- Added `Luma::getConfigParam` and support for config files
 
 ### Changed
 - N/A
@@ -51,7 +75,7 @@
 - Implement `LumaController::redirect` method
 - Add errors and flash messages, provided to views when calling `render`
 - Add database query panel and authenticated panel to debug bar
-- Provided static methods to get the current logged in user, authenticator and user provider on `Luma`
+- Provided static methods to get the current logged-in user, authenticator and user provider on `Luma`
 
 ### Changed
 - N/A

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <div>
 <!-- Version Badge -->
-<img src="https://img.shields.io/badge/Version-1.2.0-blue" alt="Version 1.2.0">
+<img src="https://img.shields.io/badge/Version-1.3.0-blue" alt="Version 1.3.0">
 <!-- PHP Coverage Badge -->
-<img src="https://img.shields.io/badge/PHP Coverage-58.93%25-red" alt="PHP Coverage 58.93%">
+<img src="https://img.shields.io/badge/PHP Coverage-55.50%25-red" alt="PHP Coverage 55.50%">
 <!-- License Badge -->
 <img src="https://img.shields.io/badge/License-GPL--3.0--or--later-34ad9b" alt="License GPL--3.0--or--later">
 </div>

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,14 @@
     "lumax/dependency-injection-component": "^1.2.0",
     "vlucas/phpdotenv": "^5.6",
     "lumax/aurora-db": "^2.6.0",
-    "lumax/security-component": "^1.4.0"
+    "lumax/security-component": "^1.4.0",
+    "symfony/console": "^7.0"
   },
   "scripts": {
     "test": "php -d xdebug.mode=coverage ./vendor/bin/phpunit --testdox --colors=always --coverage-html coverage --coverage-clover coverage/coverage.xml --testdox-html coverage/testdox.html && npx badger --phpunit ./coverage/coverage.xml && npx badger --version ./composer.json && npx badger --license ./composer.json"
   },
   "license": "GPL-3.0-or-later",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "require-dev": {
     "phpunit/phpunit": "^10.4"
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11d8aed4b3e4fa3eda96162db9ba0543",
+    "content-hash": "5c6901a3982c1144321db4902baccba7",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -194,19 +194,20 @@
         },
         {
             "name": "lumax/dependency-injection-component",
-            "version": "1.2.2",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DanielWinning/dependency-injection-component.git",
-                "reference": "f56f19bf1b5c3b56f7c4882bcd96488481b2765c"
+                "reference": "d8265f7191d9311b1845ca86426ac45ab27a5465"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DanielWinning/dependency-injection-component/zipball/f56f19bf1b5c3b56f7c4882bcd96488481b2765c",
-                "reference": "f56f19bf1b5c3b56f7c4882bcd96488481b2765c",
+                "url": "https://api.github.com/repos/DanielWinning/dependency-injection-component/zipball/d8265f7191d9311b1845ca86426ac45ab27a5465",
+                "reference": "d8265f7191d9311b1845ca86426ac45ab27a5465",
                 "shasum": ""
             },
             "require": {
+                "lumax/framework-component": "^1.1",
                 "psr/container": "^2.0",
                 "symfony/yaml": "^6.3"
             },
@@ -232,9 +233,9 @@
             "description": "A Dependency Injection Package",
             "support": {
                 "issues": "https://github.com/DanielWinning/dependency-injection-component/issues",
-                "source": "https://github.com/DanielWinning/dependency-injection-component/tree/1.2.2"
+                "source": "https://github.com/DanielWinning/dependency-injection-component/tree/1.3.0"
             },
-            "time": "2024-03-02T12:21:50+00:00"
+            "time": "2024-05-05T13:13:29+00:00"
         },
         {
             "name": "lumax/http-component",
@@ -283,16 +284,16 @@
         },
         {
             "name": "lumax/routing-component",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DanielWinning/routing-component.git",
-                "reference": "fa5efd6f2c8cd0d8282010d918c67386d476f685"
+                "reference": "03d1814e56966d48707a39f75a7f1b67ba866977"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DanielWinning/routing-component/zipball/fa5efd6f2c8cd0d8282010d918c67386d476f685",
-                "reference": "fa5efd6f2c8cd0d8282010d918c67386d476f685",
+                "url": "https://api.github.com/repos/DanielWinning/routing-component/zipball/03d1814e56966d48707a39f75a7f1b67ba866977",
+                "reference": "03d1814e56966d48707a39f75a7f1b67ba866977",
                 "shasum": ""
             },
             "require": {
@@ -325,9 +326,9 @@
             "description": "A dynamic PHP Routing Component.",
             "support": {
                 "issues": "https://github.com/DanielWinning/routing-component/issues",
-                "source": "https://github.com/DanielWinning/routing-component/tree/1.6.0"
+                "source": "https://github.com/DanielWinning/routing-component/tree/1.6.1"
             },
-            "time": "2024-05-05T10:39:31+00:00"
+            "time": "2024-05-05T14:03:41+00:00"
         },
         {
             "name": "lumax/security-component",
@@ -601,6 +602,99 @@
             "time": "2023-04-04T09:54:51+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v7.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c981e0e9380ce9f146416bde3150c79197ce9986",
+                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:29:19+00:00"
+        },
+        {
             "name": "symfony/deprecation-contracts",
             "version": "v3.5.0",
             "source": {
@@ -729,6 +823,165 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -905,6 +1158,175 @@
                 }
             ],
             "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:32:20+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
+                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/Commands/CacheClearCommand.php
+++ b/src/Commands/CacheClearCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Luma\Framework\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CacheClearCommand extends Command
+{
+    protected static string $defaultName = 'luma:cache:clear';
+
+    /**
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this->setDescription('Clears cached files.');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $cacheDirectory = sprintf('%s/cache', dirname(__DIR__, 5));
+
+        if (file_exists($cacheDirectory)) {
+            $files = glob($cacheDirectory . '/{,.}[!.,!..]*', GLOB_BRACE | GLOB_MARK);
+
+            foreach ($files as $file) {
+                if (is_file($file) && basename($file) !== '.gitignore') {
+                    unlink($file);
+                }
+            }
+
+            $output->writeln('Cache cleared successfully.');
+        } else {
+            $output->writeln('Cache directory does not exist.');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -12,6 +12,7 @@ class Installer
         self::updateGitignore();
         self::updateComposerJson();
         self::updatePackageJson();
+        self::copyEnv();
         self::installAssets();
     }
 
@@ -32,7 +33,7 @@ class Installer
      */
     private static function updateComposerJson(): void
     {
-        $composerJsonPath = self::getFilepath('composer');
+        $composerJsonPath = self::getJsonFilepath('composer');
         $composerText = file_get_contents($composerJsonPath);
         $composerJson = json_decode($composerText);
 
@@ -48,7 +49,7 @@ class Installer
      */
     private static function updatePackageJson(): void
     {
-        $packageJsonPath = self::getFilepath('package');
+        $packageJsonPath = self::getJsonFilepath('package');
         $packageText = file_get_contents($packageJsonPath);
         $packageJson = json_decode($packageText);
 
@@ -66,6 +67,20 @@ class Installer
     }
 
     /**
+     * @return void
+     */
+    private static function copyEnv(): void
+    {
+        $configDirectory = sprintf('%s/config', self::projectDirectory());
+        $source = sprintf('%s/.env.example', $configDirectory);
+        $target = sprintf('%s/.env', $configDirectory);
+
+        if (!file_exists($target) && file_exists($source)) {
+            copy($source, $target);
+        }
+    }
+
+    /**
      * @return string
      */
     private static function projectDirectory(): string
@@ -78,7 +93,7 @@ class Installer
      *
      * @return string
      */
-    private static function getFilepath(string $filename): string
+    private static function getJsonFilepath(string $filename): string
     {
         return sprintf('%s/%s.json', self::projectDirectory(), $filename);
     }

--- a/tests/Unit/LumaTest.php
+++ b/tests/Unit/LumaTest.php
@@ -32,6 +32,12 @@ class LumaTest extends TestCase
         $this->configDirectory = dirname(__DIR__) . '/config';
         $this->templateDirectory = dirname(__DIR__) . '/views';
 
+        $cachedConfig = sprintf('%s/config/config.php', $this->cacheDirectory);
+
+        if (file_exists($cachedConfig)) {
+            unlink($cachedConfig);
+        }
+
         (Dotenv::createImmutable($this->configDirectory))->safeLoad();
 
         $this->testClass = new Luma($this->configDirectory, $this->templateDirectory, $this->cacheDirectory);


### PR DESCRIPTION
## [1.3.0] - 2024-05-06
### Added
- Added `copyEnv` step to `Installer` - copies `config/.env.example` to `config/.env`.
- Added `CacheClearCommand` to work alongside planned `bin/luma` file.
- Now caching config parameters.
- Added `symfony/command`

### Changed
- N/A

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Updated the view cache directory to `cache/views`.

### Security
- N/A