### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Luma | Framework Component Changelog
 
+## [1.3.1] - 2024-05-06
+### Added
+- N/A
+
+### Changed
+- N/A
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- Fixed issue with `CacheClearCommand` name not being set.
+- Fixed issue with `CacheClearCommand` not deleting files in subdirectories.
+
+### Security
+- N/A
+
+---
+
 ## [1.3.0] - 2024-05-06
 ### Added
 - Added `copyEnv` step to `Installer` - copies `config/.env.example` to `config/.env`.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <div>
 <!-- Version Badge -->
-<img src="https://img.shields.io/badge/Version-1.3.0-blue" alt="Version 1.3.0">
+<img src="https://img.shields.io/badge/Version-1.3.1-blue" alt="Version 1.3.1">
 <!-- PHP Coverage Badge -->
-<img src="https://img.shields.io/badge/PHP Coverage-55.50%25-red" alt="PHP Coverage 55.50%">
+<img src="https://img.shields.io/badge/PHP Coverage-54.15%25-red" alt="PHP Coverage 54.15%">
 <!-- License Badge -->
 <img src="https://img.shields.io/badge/License-GPL--3.0--or--later-34ad9b" alt="License GPL--3.0--or--later">
 </div>

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "test": "php -d xdebug.mode=coverage ./vendor/bin/phpunit --testdox --colors=always --coverage-html coverage --coverage-clover coverage/coverage.xml --testdox-html coverage/testdox.html && npx badger --phpunit ./coverage/coverage.xml && npx badger --version ./composer.json && npx badger --license ./composer.json"
   },
   "license": "GPL-3.0-or-later",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "require-dev": {
     "phpunit/phpunit": "^10.4"
   }


### PR DESCRIPTION
## [1.3.1] - 2024-05-06
### Added
- N/A

### Changed
- N/A

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Fixed issue with `CacheClearCommand` name not being set.
- Fixed issue with `CacheClearCommand` not deleting files in subdirectories.

### Security
- N/A