### PR TITLE
Release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Luma | Framework Component Changelog
 
+## [1.5.2] - 2024-08-24
+### Added
+- N/A
+
+### Changed
+- N/A
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- Hotfix for `luma:cache:clear` command not matching `.log` files
+
+### Security
+- N/A
+
+---
+
 ## [1.5.1] - 2024-08-24
 ### Added
 - N/A

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div>
 <!-- Version Badge -->
-<img src="https://img.shields.io/badge/Version-1.5.1-blue" alt="Version 1.5.1">
+<img src="https://img.shields.io/badge/Version-1.5.2-blue" alt="Version 1.5.2">
 <!-- PHP Coverage Badge -->
 <img src="https://img.shields.io/badge/PHP Coverage-48.47%25-red" alt="PHP Coverage 48.47%">
 <!-- License Badge -->

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "test": "php -d xdebug.mode=coverage ./vendor/bin/phpunit --testdox --colors=always --coverage-html coverage --coverage-clover coverage/coverage.xml --testdox-html coverage/testdox.html && npx badger --phpunit ./coverage/coverage.xml && npx badger --version ./composer.json && npx badger --license ./composer.json"
   },
   "license": "GPL-3.0-or-later",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "require-dev": {
     "phpunit/phpunit": "^10.4"
   }

--- a/src/Commands/CacheClearCommand.php
+++ b/src/Commands/CacheClearCommand.php
@@ -54,7 +54,7 @@ class CacheClearCommand extends Command
         if (file_exists($logDirectory)) {
             $directory = new \RecursiveDirectoryIterator($logDirectory, \FilesystemIterator::SKIP_DOTS);
             $iterator = new \RecursiveIteratorIterator($directory);
-            $files = new \RegexIterator($iterator, '/^.+(\.html|\.html\.log)$/i', \RegexIterator::GET_MATCH);
+            $files = new \RegexIterator($iterator, '/^.+(\.html|\.log)$/i', \RegexIterator::GET_MATCH);
 
             foreach ($files as $file) {
                 $filePath = $file[0];


### PR DESCRIPTION
## [1.5.2] - 2024-08-24
### Added
- N/A

### Changed
- N/A

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Hotfix for `luma:cache:clear` command not matching `.log` files

### Security
- N/A