### PR TITLE
Release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Luma | Framework Component Changelog
 
+## [1.7.2] - 2024-11-19
+### Changed
+- `Luma::run()` no longer echoes the response - this should now be handled by the calling code.
+
+---
+
 ## [1.7.1] - 2024-11-19
 ### Removed
 - Removed unused assets

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <div>
 <!-- Version Badge -->
-<img src="https://img.shields.io/badge/Version-1.7.1-blue" alt="Version 1.7.1">
+<img src="https://img.shields.io/badge/Version-1.7.2-blue" alt="Version 1.7.2">
 <!-- PHP Coverage Badge -->
-<img src="https://img.shields.io/badge/PHP Coverage-54.58%25-red" alt="PHP Coverage 54.58%">
+<img src="https://img.shields.io/badge/PHP Coverage-54.01%25-red" alt="PHP Coverage 54.01%">
 <!-- License Badge -->
 <img src="https://img.shields.io/badge/License-GPL--3.0--or--later-34ad9b" alt="License GPL--3.0--or--later">
 </div>

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "analyse": "./vendor/bin/phpstan analyse -c phpstan.neon"
   },
   "license": "GPL-3.0-or-later",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "require-dev": {
     "phpunit/phpunit": "^10.4",
     "phpstan/phpstan": "^1.12"

--- a/src/Luma.php
+++ b/src/Luma.php
@@ -76,8 +76,6 @@ final class Luma
             }
         }
 
-        $this->echoResponse($response);
-
         return $response;
     }
 
@@ -205,16 +203,6 @@ final class Luma
                 $_ENV['DATABASE_PASSWORD']
             )
         );
-    }
-
-    /**
-     * @param Response $response
-     *
-     * @return void
-     */
-    private function echoResponse(Response $response): void
-    {
-        echo $response->getBody()->getContents();
     }
 
     /**

--- a/tests/Unit/LumaTest.php
+++ b/tests/Unit/LumaTest.php
@@ -72,9 +72,9 @@ class LumaTest extends TestCase
     public function testItRuns(array $data, string $expectedOutput): void
     {
         $request = $this->setupRequest($data['path'], $data['method']);
+        $response = $this->testClass->run($request);
 
-        $this->expectOutputString($expectedOutput);
-        $this->testClass->run($request);
+        self::assertEquals($expectedOutput, $response->getBody()->getContents());
     }
 
     /**
@@ -89,9 +89,9 @@ class LumaTest extends TestCase
     public function testItRenders(string $path): void
     {
         $request = $this->setupRequest($path, 'GET');
+        $response = $this->testClass->run($request);
 
-        $this->expectOutputString('<h1>Hello, Render Test!</h1>');
-        $this->testClass->run($request);
+        self::assertEquals('<h1>Hello, Render Test!</h1>', $response->getBody()->getContents());
     }
 
     /**


### PR DESCRIPTION
## [1.7.2] - 2024-11-19
### Changed
- `Luma::run()` no longer echoes the response - this should now be handled by the calling code.